### PR TITLE
Add license and repo to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "version": "v0.0.1",
   "repository": {
     "type": "git",
-    "url": "git://github.com/zotero/citeproc-js-node.git"
+    "url": "git://github.com/fcheslack/citeproc-js-node.git"
   },
+  "license": "MPL-1.1",
   "engines": {
     "node": ">=0.12"
   },


### PR DESCRIPTION
At the moment the `npm` repo points to the wrong repository and the license is not defined. This pull request updates `package.json`.
