### PR TITLE
Fix fatal bug if myjson is undefined

### DIFF
--- a/src/csl_json.js
+++ b/src/csl_json.js
@@ -243,6 +243,9 @@ CSL_JSON.prototype.getNodesByName = function (myjson,name,nameattrval,ret) {
 
 CSL_JSON.prototype.nodeNameIs = function (myjson,name) {
     //print("nodeNameIs()");
+    if (typeof myjson == "undefined") {
+        return false;
+    }
     if (name == myjson.name) {
         return true;
     }


### PR DESCRIPTION
Running the test script described at https://github.com/fcheslack/citeproc-js-node causes the following fatal bug:

```
/whatever$ node ./test.js
/whatever/node_modules/citeproc-js-node/src/csl_json.js:249
    if (name == myjson.name) {
                      ^

TypeError: Cannot read property 'name' of undefined
    at CSL_JSON.nodeNameIs (/whatever/node_modules/citeproc-js-node/src/csl_json.js:249:23)
    at CSL.Engine.localeSet (/whatever/node_modules/citeproc-js-node/src/citeproc.js:5046:22)
    at CSL.Engine.localeConfigure (/whatever/node_modules/citeproc-js-node/src/citeproc.js:4993:14)
    at new CSL.Engine (/whatever/node_modules/citeproc-js-node/src/citeproc.js:1450:10)
    at exports.simpleSys.newEngine (/whatever/node_modules/citeproc-js-node/src/citeprocnode.js:58:21)
    at Object.<anonymous> (/whatever/test.js:9:18)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
    at run (bootstrap_node.js:352:7)
    at startup (bootstrap_node.js:144:9)
    at bootstrap_node.js:467:3
```
